### PR TITLE
Adding a Footer to GalleryPage & EmptyPage with Copyrights & LinkedIn Profile Links

### DIFF
--- a/react_app/src/components/Footer.js
+++ b/react_app/src/components/Footer.js
@@ -1,0 +1,27 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Link from '@mui/material/Link';
+
+function Copyright() {
+  return (
+    <Typography variant="body2" color="text.secondary" align="center">
+      {"Copyright © "}
+      <Link color="inherit" underline="hover" href="https://www.linkedin.com/in/liorkgow/">
+        Lior Keren
+      </Link>
+      {" & "}
+      <Link color="inherit" underline="hover" href="https://www.linkedin.com/in/guy-sternshos/">
+        Guy Sternshos
+      </Link>{" "}
+      {new Date().getFullYear()}
+    </Typography>
+  );
+};
+
+const Footer = () => (
+  <Box sx={{ bgcolor: "background.paper", p: 6 }} component="footer">
+    <Copyright />
+  </Box>
+);
+
+export default Footer;

--- a/react_app/src/pages/EmptyPage.js
+++ b/react_app/src/pages/EmptyPage.js
@@ -1,11 +1,13 @@
 import { Container, Typography } from "@mui/material";
 
 import NavBar from "../components/NavBar";
+import Footer from "../components/Footer";
 
 const EmptyPage = () => {
   return (
-    <>
+    <div className="empty-page">
       <NavBar />
+
       <Container maxWidth="sm" className="empty-page-content">
         <Typography
           component="h1"
@@ -25,7 +27,9 @@ const EmptyPage = () => {
           It will be added in the future !
         </Typography>
       </Container>
-    </>
+
+      <Footer />
+    </div>
   );
 };
 

--- a/react_app/src/pages/GalleryPage.js
+++ b/react_app/src/pages/GalleryPage.js
@@ -3,6 +3,7 @@ import { Typography, Container } from "@mui/material";
 
 import NavBar from "../components/NavBar";
 import Gallery from "../components/Gallery";
+import Footer from "../components/Footer";
 
 import { cards } from "../resources/Mock Data/mockData";
 
@@ -32,6 +33,8 @@ const GalleryPage = () => {
       </Container>
 
       <Gallery cards={cards} />
+
+      <Footer />
     </div>
   );
 };

--- a/react_app/src/resources/Mock Data/mockData.js
+++ b/react_app/src/resources/Mock Data/mockData.js
@@ -37,10 +37,4 @@ export const cards = [
         "description": "bla bla bla 1231",
         "image": "https://previews.123rf.com/images/bowie15/bowie151401/bowie15140100076/39843044-shocked-face-guy.jpg",
     },
-    {
-        "id": 11,
-        "title": "Lorem ipsum dolor sit amet",
-        "description": "bla bla bla 11",
-        "image": "https://source.unsplash.com/random?wallpapers",
-    },
 ];


### PR DESCRIPTION
The Footer of the pages contain links to our LinkedIn profiles alongside with the year of creating this project

-------------------------------------------------

Screenshots:

The Footer:
![Footer](https://github.com/LiorKGOW/EmoLens-React/assets/93318917/04590f78-679a-4188-8121-cac05e80f5ae)

The names are links:

![Names are links (Lior)](https://github.com/LiorKGOW/EmoLens-React/assets/93318917/f78f4d1a-8fd4-4865-9fdd-aee109dd8286)

![Names are links (Guy)](https://github.com/LiorKGOW/EmoLens-React/assets/93318917/f6faccc7-1aed-4e7a-bad6-e7c9d2c41210)

-------------------------------------------------

Whole Pages:

Gallery Page:
![Whole Page - Gallery Page](https://github.com/LiorKGOW/EmoLens-React/assets/93318917/9e237a04-f12c-4bcf-b055-75f8533fe6a8)

Empty Page:
![Whole Page - Empty Page](https://github.com/LiorKGOW/EmoLens-React/assets/93318917/0505d3ca-0c9c-4947-8919-df19e058ea17)